### PR TITLE
Add missing ordering relationship

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,5 +25,6 @@ class nano::config
         owner   => $::os::params::adminuser,
         group   => $::os::params::admingroup,
         mode    => '0644',
+        require => Package['nano'],
     }
 }


### PR DESCRIPTION
This pull request adds missing ordering relationship between Package[nano] and File[nano-nanorc].